### PR TITLE
Render from POST Body

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -13,6 +13,10 @@ func main() {
 	log.Print("Chart server starting up")
 
 	http.HandleFunc("/chart", server.RenderGV)
+	http.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		return
+	})
 
 	port := os.Getenv("PORT")
 	if port == "" {


### PR DESCRIPTION
Allows handling bigger payloads, since the form payloads are often sent as `params` instead of in the body